### PR TITLE
add compression of TFileService for the ShallowTree class  - control …

### DIFF
--- a/CalibTracker/SiStripChannelGain/python/ntuple_cff.py
+++ b/CalibTracker/SiStripChannelGain/python/ntuple_cff.py
@@ -37,24 +37,38 @@ OfflineChannelGainOutputCommands =  [
                                      'keep *_shallowGainCalibration_*_*'
                                     ]
 
+
+# Use compressiong settings of TFile
+# see https://root.cern.ch/root/html534/TFile.html#TFile:SetCompressionSettings
+# settings = 100 * algorithm + level
+# level is from 1 (small) to 9 (large compression)
+# algo: 1 (ZLIB), 2 (LMZA)
+# see more about compression & performance: https://root.cern.ch/root/html534/guides/users-guide/InputOutput.html#compression-and-performance
+compressionSettings = 201
+
 gainCalibrationTreeAagBunch = cms.EDAnalyzer("ShallowTree", outputCommands = cms.untracked.vstring('drop *'))
 gainCalibrationTreeAagBunch.outputCommands += OfflineChannelGainOutputCommands
+gainCalibrationTreeAagBunch.CompressionSettings = cms.untracked.int32(compressionSettings)
 
 gainCalibrationTreeAagBunch0T = cms.EDAnalyzer("ShallowTree", outputCommands = cms.untracked.vstring('drop *'))
 gainCalibrationTreeAagBunch0T.outputCommands += OfflineChannelGainOutputCommands
+gainCalibrationTreeAagBunch0T.CompressionSettings = cms.untracked.int32(compressionSettings)
 
 gainCalibrationTreeStdBunch = cms.EDAnalyzer("ShallowTree", outputCommands = cms.untracked.vstring('drop *'))
 gainCalibrationTreeStdBunch.outputCommands += OfflineChannelGainOutputCommands
+gainCalibrationTreeStdBunch.CompressionSettings = cms.untracked.int32(compressionSettings)
 
 gainCalibrationTreeStdBunch0T = cms.EDAnalyzer("ShallowTree", outputCommands = cms.untracked.vstring('drop *'))
 gainCalibrationTreeStdBunch0T.outputCommands += OfflineChannelGainOutputCommands
+gainCalibrationTreeStdBunch0T.CompressionSettings = cms.untracked.int32(compressionSettings)
 
 gainCalibrationTreeIsoMuon = cms.EDAnalyzer("ShallowTree", outputCommands = cms.untracked.vstring('drop *'))
 gainCalibrationTreeIsoMuon.outputCommands += OfflineChannelGainOutputCommands
+gainCalibrationTreeIsoMuon.CompressionSettings = cms.untracked.int32(compressionSettings)
 
 gainCalibrationTreeIsoMuon0T = cms.EDAnalyzer("ShallowTree", outputCommands = cms.untracked.vstring('drop *'))
 gainCalibrationTreeIsoMuon0T.outputCommands += OfflineChannelGainOutputCommands
-
+gainCalibrationTreeIsoMuon0T.CompressionSettings = cms.untracked.int32(compressionSettings)
 
 
 inputDataSequence = cms.Sequence( shallowEventRun + shallowTracks + shallowGainCalibration )

--- a/CalibTracker/SiStripCommon/plugins/ShallowTree.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowTree.cc
@@ -8,6 +8,10 @@
 #include <TBranch.h>
 
 ShallowTree::ShallowTree(const edm::ParameterSet& iConfig) {
+  //int compSettings= iConfig.getParameter<int>("CompressionSettings",-1);
+  int compSettings= iConfig.getUntrackedParameter<int>("CompressionSettings",-1);
+  if(compSettings>0)
+  	fs_->file().SetCompressionSettings(compSettings);
   tree_ = fs_->make<TTree>("tree", ""); 
 
   std::map<std::string, LEAFTYPE> leafmap;

--- a/CalibTracker/SiStripCommon/test/testProduceCalibrationTree_cfg.py
+++ b/CalibTracker/SiStripCommon/test/testProduceCalibrationTree_cfg.py
@@ -95,19 +95,19 @@ process.shallowTracks.Tracks  = cms.InputTag( options.inputCollection )
 ## process.L1T1.L1TechTriggerSeeding = cms.bool(True)
 ## process.L1T1.L1SeedsLogicalExpression = cms.string('(40 OR 41) AND NOT (36 OR 37 OR 38 OR 39)')
 
-compressionSettings = 201
+#compressionSettings = 201
 process.EventInfo = cms.EDAnalyzer("ShallowTree", 
-					CompressionSettings = cms.untracked.int32(compressionSettings),
+					CompressionSettings = process.gainCalibrationTreeStdBunch.CompressionSettings,
                             		outputCommands = cms.untracked.vstring('drop *',
                                                                           'keep *_shallowEventRun_*_*',
                                                                           )
                                    )
-process.gainCalibrationTreeStdBunch.CompressionSettings = cms.untracked.int32(compressionSettings)
-process.gainCalibrationTreeStdBunch0T.CompressionSettings = cms.untracked.int32(compressionSettings)
-process.gainCalibrationTreeIsoMuon.CompressionSettings = cms.untracked.int32(compressionSettings)
-process.gainCalibrationTreeIsoMuon0T.CompressionSettings = cms.untracked.int32(compressionSettings)
-process.gainCalibrationTreeAagBunch.CompressionSettings = cms.untracked.int32(compressionSettings)
-process.gainCalibrationTreeAagBunch0T.CompressionSettings = cms.untracked.int32(compressionSettings)
+#process.gainCalibrationTreeStdBunch.CompressionSettings = cms.untracked.int32(compressionSettings)
+#process.gainCalibrationTreeStdBunch0T.CompressionSettings = cms.untracked.int32(compressionSettings)
+#process.gainCalibrationTreeIsoMuon.CompressionSettings = cms.untracked.int32(compressionSettings)
+#process.gainCalibrationTreeIsoMuon0T.CompressionSettings = cms.untracked.int32(compressionSettings)
+#process.gainCalibrationTreeAagBunch.CompressionSettings = cms.untracked.int32(compressionSettings)
+#process.gainCalibrationTreeAagBunch0T.CompressionSettings = cms.untracked.int32(compressionSettings)
 
 #process.TkCalPath = cms.Path(process.L1T1*process.TkCalFullSequence)
 

--- a/CalibTracker/SiStripCommon/test/testProduceCalibrationTree_cfg.py
+++ b/CalibTracker/SiStripCommon/test/testProduceCalibrationTree_cfg.py
@@ -53,6 +53,7 @@ print "outputFile        : ", options.outputFile
 print "inputFiles        : ", options.inputFiles
 
 process = cms.Process('CALIB')
+#from CalibTracker.SiStripChannelGain.ntuple_cff import *
 process.load('CalibTracker.Configuration.setupCalibrationTree_cff')
 process.load('CalibTracker.SiStripCommon.ShallowEventDataProducer_cfi') #event Info
 
@@ -94,13 +95,22 @@ process.shallowTracks.Tracks  = cms.InputTag( options.inputCollection )
 ## process.L1T1.L1TechTriggerSeeding = cms.bool(True)
 ## process.L1T1.L1SeedsLogicalExpression = cms.string('(40 OR 41) AND NOT (36 OR 37 OR 38 OR 39)')
 
-process.EventInfo = cms.EDAnalyzer("ShallowTree",
-                                   outputCommands = cms.untracked.vstring('drop *',
+compressionSettings = 201
+process.EventInfo = cms.EDAnalyzer("ShallowTree", 
+					CompressionSettings = cms.untracked.int32(compressionSettings),
+                            		outputCommands = cms.untracked.vstring('drop *',
                                                                           'keep *_shallowEventRun_*_*',
                                                                           )
                                    )
+process.gainCalibrationTreeStdBunch.CompressionSettings = cms.untracked.int32(compressionSettings)
+process.gainCalibrationTreeStdBunch0T.CompressionSettings = cms.untracked.int32(compressionSettings)
+process.gainCalibrationTreeIsoMuon.CompressionSettings = cms.untracked.int32(compressionSettings)
+process.gainCalibrationTreeIsoMuon0T.CompressionSettings = cms.untracked.int32(compressionSettings)
+process.gainCalibrationTreeAagBunch.CompressionSettings = cms.untracked.int32(compressionSettings)
+process.gainCalibrationTreeAagBunch0T.CompressionSettings = cms.untracked.int32(compressionSettings)
 
 #process.TkCalPath = cms.Path(process.L1T1*process.TkCalFullSequence)
+
 process.TkCalPath_StdBunch   = cms.Path(process.TkCalSeq_StdBunch*process.shallowEventRun*process.EventInfo)
 process.TkCalPath_StdBunch0T = cms.Path(process.TkCalSeq_StdBunch0T*process.shallowEventRun*process.EventInfo)
 process.TkCalPath_IsoMuon    = cms.Path(process.TkCalSeq_IsoMuon*process.shallowEventRun*process.EventInfo)


### PR DESCRIPTION
 Add compression settings for the TFile used in the TFileService instance of the ShallowTree class.
 The code reads the factor from the config file and by default its remains with the default compression.
 The change in the config file are only used in testProduceCalibrationTree_cfg.py
 The test show a possible 13% space reduction for an increase of 15% in the production time (settings 201). A more agressive approach could give up to 18% space reduction but for a large increase in the production.
 If we are fine, you could apply the same recipe in MakeCalibrationTrees/produceCalibrationTree_template_cfg.py to use that for the calibTrees production.