### PR TITLE
Restore mistakenly removed vars

### DIFF
--- a/CalibTracker/SiStripHitEfficiency/interface/HitEff.h
+++ b/CalibTracker/SiStripHitEfficiency/interface/HitEff.h
@@ -84,6 +84,7 @@ class HitEff : public edm::EDAnalyzer {
   TTree* traj;
   int events,EventTrackCKF;
   
+  int compSettings;
   unsigned int layers;
   bool DEBUG;
   unsigned int whatlayer;
@@ -95,12 +96,12 @@ class HitEff : public edm::EDAnalyzer {
   int timeDTDOF; 
   float timeECAL, dedx; 
   int dedxNOM; 
-  float TrajLocErrX, TrajLocErrY;
   int nLostHits; 
   float p, chi2; 
   #endif
   float TrajGlbX, TrajGlbY, TrajGlbZ;
   float TrajLocX, TrajLocY, TrajLocAngleX, TrajLocAngleY;
+  float TrajLocErrX, TrajLocErrY;
   float ClusterLocX, ClusterLocY, ClusterLocErrX, ClusterLocErrY, ClusterStoN;
   float ResX, ResXSig;
   unsigned int ModIsBad; unsigned int Id; unsigned int SiStripQualBad; bool withinAcceptance;

--- a/CalibTracker/SiStripHitEfficiency/interface/HitEff.h
+++ b/CalibTracker/SiStripHitEfficiency/interface/HitEff.h
@@ -91,16 +91,15 @@ class HitEff : public edm::EDAnalyzer {
   // Tree declarations
   // Trajectory positions for modules included in the study
   #ifdef ExtendedCALIBTree
-  float TrajGlbX, TrajGlbY, TrajGlbZ;
   float timeDT, timeDTErr; 
   int timeDTDOF; 
   float timeECAL, dedx; 
   int dedxNOM; 
   float TrajLocErrX, TrajLocErrY;
-  int istep;
   int nLostHits; 
   float p, chi2; 
   #endif
+  float TrajGlbX, TrajGlbY, TrajGlbZ;
   float TrajLocX, TrajLocY, TrajLocAngleX, TrajLocAngleY;
   float ClusterLocX, ClusterLocY, ClusterLocErrX, ClusterLocErrY, ClusterStoN;
   float ResX, ResXSig;

--- a/CalibTracker/SiStripHitEfficiency/python/SiStripHitEff_cff.py
+++ b/CalibTracker/SiStripHitEfficiency/python/SiStripHitEff_cff.py
@@ -1,6 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 
+# Use compressiong settings of TFile
+# see https://root.cern.ch/root/html534/TFile.html#TFile:SetCompressionSettings
+# settings = 100 * algorithm + level
+# level is from 1 (small) to 9 (large compression)
+# algo: 1 (ZLIB), 2 (LMZA)
+# see more about compression & performance: https://root.cern.ch/root/html534/guides/users-guide/InputOutput.html#compression-and-performance
+compressionSettings = 201
+
 anEff = cms.EDAnalyzer("HitEff",
+                       #CompressionSettings = cms.untracked.int32(compressionSettings),
                        Debug = cms.bool(False),
                        Layer = cms.int32(0), # =0 means do all layers
                        #combinatorialTracks = cms.InputTag("ctfWithMaterialTracksP5"),

--- a/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
+++ b/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
@@ -82,6 +82,7 @@ HitEff::HitEff(const edm::ParameterSet& conf) :
   trackerEvent_token_( consumes< MeasurementTrackerEvent>(conf.getParameter<edm::InputTag>("trackerEvent")) ),
   conf_(conf)
 {
+  compSettings=conf_.getUntrackedParameter<int>("CompressionSettings",-1);
   layers =conf_.getParameter<int>("Layer");
   DEBUG = conf_.getParameter<bool>("Debug");
   addLumi_ = conf_.getUntrackedParameter<bool>("addLumi", false);
@@ -99,6 +100,10 @@ HitEff::~HitEff() { }
 void HitEff::beginJob(){
 
   edm::Service<TFileService> fs;
+  if(compSettings>0){
+    edm::LogInfo("SiStripHitEfficiency:HitEff")<<"the compressions settings are:"<< compSettings << std::endl;
+    fs->file().SetCompressionSettings(compSettings);
+  }
 
   traj = fs->make<TTree>("traj","tree of trajectory positions");
   #ifdef ExtendedCALIBTree
@@ -108,8 +113,6 @@ void HitEff::beginJob(){
   traj->Branch("timeECAL",&timeECAL,"timeECAL/F");
   traj->Branch("dedx",&dedx,"dedx/F");
   traj->Branch("dedxNOM",&dedxNOM,"dedxNOM/I"); 
-  traj->Branch("TrajLocErrX",&TrajLocErrX,"TrajLocErrX/F");
-  traj->Branch("TrajLocErrY",&TrajLocErrY,"TrajLocErrY/F");
   traj->Branch("nLostHits",&nLostHits,"nLostHits/I");
   traj->Branch("chi2",&chi2,"chi2/F");
   traj->Branch("p",&p,"p/F");
@@ -121,6 +124,8 @@ void HitEff::beginJob(){
   traj->Branch("TrajLocY",&TrajLocY,"TrajLocY/F");
   traj->Branch("TrajLocAngleX",&TrajLocAngleX,"TrajLocAngleX/F");
   traj->Branch("TrajLocAngleY",&TrajLocAngleY,"TrajLocAngleY/F");
+  traj->Branch("TrajLocErrX",&TrajLocErrX,"TrajLocErrX/F");
+  traj->Branch("TrajLocErrY",&TrajLocErrY,"TrajLocErrY/F");
   traj->Branch("ClusterLocX",&ClusterLocX,"ClusterLocX/F");
   traj->Branch("ClusterLocY",&ClusterLocY,"ClusterLocY/F");
   traj->Branch("ClusterLocErrX",&ClusterLocErrX,"ClusterLocErrX/F");
@@ -537,9 +542,7 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es){
 	  angleX = atan( TM->localDxDz() );
 	  angleY = atan( TM->localDyDz() );
 
-#ifdef ExtendedCALIBTree	  
 	  TrajLocErrX = 0.0; TrajLocErrY = 0.0;
-#endif
 
 	  xglob = TM->globalX();
 	  yglob = TM->globalY();
@@ -728,10 +731,9 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es){
 	      TrajGlbY = yglob;
 	      TrajGlbZ = zglob;	
   
-#ifdef ExtendedCALIBTree
 	      TrajLocErrX = xErr;
 	      TrajLocErrY = yErr;
-#endif
+
 	      Id = iidd;
 	      run = run_nr;
 	      event = ev_nr;

--- a/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
+++ b/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
@@ -102,9 +102,6 @@ void HitEff::beginJob(){
 
   traj = fs->make<TTree>("traj","tree of trajectory positions");
   #ifdef ExtendedCALIBTree
-  traj->Branch("TrajGlbX",&TrajGlbX,"TrajGlbX/F");
-  traj->Branch("TrajGlbY",&TrajGlbY,"TrajGlbY/F");
-  traj->Branch("TrajGlbZ",&TrajGlbZ,"TrajGlbZ/F");
   traj->Branch("timeDT",&timeDT,"timeDT/F");
   traj->Branch("timeDTErr",&timeDTErr,"timeDTErr/F");
   traj->Branch("timeDTDOF",&timeDTDOF,"timeDTDOF/I");
@@ -113,11 +110,13 @@ void HitEff::beginJob(){
   traj->Branch("dedxNOM",&dedxNOM,"dedxNOM/I"); 
   traj->Branch("TrajLocErrX",&TrajLocErrX,"TrajLocErrX/F");
   traj->Branch("TrajLocErrY",&TrajLocErrY,"TrajLocErrY/F");
-  traj->Branch("istep",&istep,"istep/I");
   traj->Branch("nLostHits",&nLostHits,"nLostHits/I");
   traj->Branch("chi2",&chi2,"chi2/F");
   traj->Branch("p",&p,"p/F");
   #endif
+  traj->Branch("TrajGlbX",&TrajGlbX,"TrajGlbX/F");
+  traj->Branch("TrajGlbY",&TrajGlbY,"TrajGlbY/F");
+  traj->Branch("TrajGlbZ",&TrajGlbZ,"TrajGlbZ/F");
   traj->Branch("TrajLocX",&TrajLocX,"TrajLocX/F");
   traj->Branch("TrajLocY",&TrajLocY,"TrajLocY/F");
   traj->Branch("TrajLocAngleX",&TrajLocAngleX,"TrajLocAngleX/F");
@@ -358,11 +357,8 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es){
       double yErr = 0.;
       double angleX = -999.;
       double angleY = -999.;
-#ifdef ExtendedCALIBTree      
       double xglob,yglob,zglob;
-#endif
-      
-	  
+      	  
 	  // Check whether the trajectory has some missing hits
 	  bool hasMissingHits=false;
 	  for (itm=TMeas.begin();itm!=TMeas.end();itm++){
@@ -542,14 +538,16 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es){
 	  angleY = atan( TM->localDyDz() );
 
 #ifdef ExtendedCALIBTree	  
+	  TrajLocErrX = 0.0; TrajLocErrY = 0.0;
+#endif
+
 	  xglob = TM->globalX();
 	  yglob = TM->globalY();
 	  zglob = TM->globalZ();
 	  xErr =  TM->localErrorX();
 	  yErr =  TM->localErrorY();
-	  TrajLocErrX = 0.0; TrajLocErrY = 0.0;
+
 	  TrajGlbX = 0.0; TrajGlbY = 0.0; TrajGlbZ = 0.0;
-#endif
 	  withinAcceptance = TM->withinAcceptance();
 	  
 	  trajHitValid = TM->validHit();
@@ -726,10 +724,11 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es){
 	      
 	      // fill ntuple varibles
 	      //get global position from module id number iidd
-#ifdef ExtendedCALIBTree
 	      TrajGlbX = xglob;
 	      TrajGlbY = yglob;
-	      TrajGlbZ = zglob;	  
+	      TrajGlbZ = zglob;	
+  
+#ifdef ExtendedCALIBTree
 	      TrajLocErrX = xErr;
 	      TrajLocErrY = yErr;
 #endif


### PR DESCRIPTION
Following up the comments from @jlagram in:

   * https://github.com/CMSTrackerDPG/cmssw/pull/4#discussion_r182484931
   * https://github.com/CMSTrackerDPG/cmssw/pull/4#discussion_r182486433
   * https://github.com/CMSTrackerDPG/cmssw/pull/4#discussion_r182488357

I have restored `TrajGlbX`, `TrajGlbY`, `TrajGlbZ` in the tree output, as well as re-added the `xErr` and `yErr` computation (even if they are not stored anymore in the output tree). The unused variable `istep` is not booked anymore.  