### PR TITLE
add originalAlgo to the anEff tree in calibTrees

### DIFF
--- a/CalibTracker/SiStripHitEfficiency/interface/HitEff.h
+++ b/CalibTracker/SiStripHitEfficiency/interface/HitEff.h
@@ -105,7 +105,8 @@ class HitEff : public edm::EDAnalyzer {
   float ClusterLocX, ClusterLocY, ClusterLocErrX, ClusterLocErrY, ClusterStoN;
   float ResX, ResXSig;
   unsigned int ModIsBad; unsigned int Id; unsigned int SiStripQualBad; bool withinAcceptance;
-  int nHits; 
+  int nHits;
+  unsigned int originalAlgo;
   float pT;
   bool highPurity;
   unsigned int trajHitValid, run, event, bunchx;

--- a/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
+++ b/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
@@ -138,6 +138,7 @@ void HitEff::beginJob(){
   traj->Branch("withinAcceptance",&withinAcceptance,"withinAcceptance/O");
   traj->Branch("nHits",&nHits,"nHits/I");
   traj->Branch("pT",&pT,"pT/F");
+  traj->Branch("originalAlgo",&originalAlgo,"originalAlgo/i");
   traj->Branch("highPurity",&highPurity,"highPurity/O");
   traj->Branch("trajHitValid", &trajHitValid, "trajHitValid/i");
   traj->Branch("Id",&Id,"Id/i");
@@ -350,9 +351,8 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es){
 		   itraj->lastMeasurement().updatedState().globalMomentum().y()) );
       
       // track quality
-	  highPurity = itrack->quality(reco::TrackBase::TrackQuality::highPurity);
-
-      
+      highPurity = itrack->quality(reco::TrackBase::TrackQuality::highPurity);
+      originalAlgo = itrack->originalAlgo();
       
       std::vector<TrajectoryMeasurement> TMeas=itraj->measurements();
       vector<TrajectoryMeasurement>::iterator itm;


### PR DESCRIPTION
Add `originalAlgo` to anEff tree for checking if strip-seeded iterations are affecting the measuerement.